### PR TITLE
Simulation initialization fix

### DIFF
--- a/src/asdm/asdm.py
+++ b/src/asdm/asdm.py
@@ -2101,6 +2101,10 @@ class sdmodel(object):
             dt = self.sim_specs['dt']
         iterations = int(time/dt)
 
+        # TODO: state code below is not running this on first sim. What are the possible states when calling simulate? are there instances when we wouldn't want to re-parse the equations?
+        self.parse()
+        self.generate_ordered_vars()
+
         if self.state in ['simulated', 'changed']:
             if self.state == 'changed':
                 self.logger.debug('Equation changed after last simulation, re-parsing.')

--- a/tests/test_sdmodel.py
+++ b/tests/test_sdmodel.py
@@ -1,0 +1,22 @@
+import pytest
+from asdm import sdmodel
+from asdm.utilities import plot_time_series
+
+class GoalGap(sdmodel):
+    def __init__(self):
+        super(GoalGap, self).__init__()
+        self.add_stock("Stock", 100, in_flows=['Flow'])
+        self.add_aux("Goal", 20)
+        self.add_aux("Adjustment_time", 5)
+        self.add_aux("Gap", "Goal-Stock")
+        self.add_flow("Flow", "Gap/Adjustment_time")
+
+@pytest.fixture
+def goal_gap_model():
+    return GoalGap()
+
+def test_init(goal_gap_model):
+    pass
+
+def test_simulation(goal_gap_model):
+    goal_gap_model.simulate(time=20, dt=1)


### PR DESCRIPTION
This is a quick fix for #38. The simulation was not properly initialized when running `.simulate`. See the TODO note. I also added a test for creation and simulation of the simple goal gap model.